### PR TITLE
Add instructions for installing vagrant on Win 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,12 @@ Then close and reopen msys2
 
 Follow GitHub's [instructions for adding an ssh key](https://help.github.com/articles/adding-a-new-ssh-key-to-your-github-account/#platform-windows) to your account, and [testing your ssh connection](https://help.github.com/articles/testing-your-ssh-connection/) with GitHub. 
 
+# Install VirtualBox and Vagrant
 
+## Virtualbox 
+Download and install the latest VirtualBox Platform Pack and VirtualBox Extension Pack from https://www.virtualbox.org.
 
-# Install Vagrant
+##Vagrant
 
 Download and install [https://www.vagrantup.com/](https://www.vagrantup.com/)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Install MSYS2 64
+# Install MSYS2 64
 Get msys2  from http://msys2.github.io/
 
 ## Note that you can copy/paste the commands in the code blocks
@@ -85,3 +85,14 @@ Then close and reopen msys2
 # Set up your SSH Key at GitHub
 
 Follow GitHub's [instructions for adding an ssh key](https://help.github.com/articles/adding-a-new-ssh-key-to-your-github-account/#platform-windows) to your account, and [testing your ssh connection](https://help.github.com/articles/testing-your-ssh-connection/) with GitHub. 
+
+
+
+# Install Vagrant
+
+Download and install [https://www.vagrantup.com/](https://www.vagrantup.com/)
+
+Windows 10 users may run in to [this bug](https://github.com/mitchellh/vagrant/issues/6852) and need to [install some additional libraries](https://www.microsoft.com/en-us/download/details.aspx?id=8328) to get vagrant working. 
+
+
+


### PR DESCRIPTION
## Motivation and Context

We're moving to vagrant being a default part of the dev environment and Windows 10 needs a little help to make that work. 
## How Has This Been Tested?

Got vagrant working on Windows 10
