### PR TITLE
Handle non-default key names

### DIFF
--- a/ssh-agent.sh
+++ b/ssh-agent.sh
@@ -46,9 +46,15 @@ fi
 # to paste the proper path after ssh-add
 if ! agent_is_running; then
     agent_start
-    ssh-add
+    for file in $(grep IdentityFile ~/.ssh/config | awk '{print $2}') ;
+      do ssh-add "$file"; 
+    done
+
 elif ! agent_has_keys; then
-    ssh-add
+    for file in $(grep IdentityFile ~/.ssh/config | awk '{print $2}') ;
+      do ssh-add "$file";
+    done
+
 fi
 
 unset env


### PR DESCRIPTION
This adds a quick `awk` for keys. 

Alternately, we could simply add a note to the docs recommending default key names. It's possible that this is a "my problem" thing and not an "our problem" thing. 
